### PR TITLE
Support Result<T,_> in a way similar to Option<T>.

### DIFF
--- a/fp-core/src/applicative.rs
+++ b/fp-core/src/applicative.rs
@@ -4,3 +4,5 @@ use crate::pure::Pure;
 pub trait Applicative<A, B>: Apply<B> + Pure<A> {}
 
 impl<A, B> Applicative<A, B> for Option<A> {}
+
+impl<A, B, E> Applicative<A, B> for Result<A, E> {}

--- a/fp-core/src/apply.rs
+++ b/fp-core/src/apply.rs
@@ -12,3 +12,9 @@ impl<A, B> Apply<B> for Option<A> {
         self.and_then(|v| f.map(|z| z(v)))
     }
 }
+
+impl<A, B, E> Apply<B> for Result<A, E> {
+    fn ap(self, f: Applicator<B, Self>) -> <Self as HKT<B>>::Target {
+        self.and_then(|v| f.map(|z| z(v)))
+    }
+}

--- a/fp-core/src/chain.rs
+++ b/fp-core/src/chain.rs
@@ -14,3 +14,12 @@ impl<A, B> Chain<B> for Option<A> {
         self.and_then(f)
     }
 }
+
+impl<A, B, E> Chain<B> for Result<A, E> {
+    fn chain<F>(self, f: F) -> Self::Target
+    where
+        F: FnOnce(A) -> <Self as HKT<B>>::Target,
+    {
+        self.and_then(f)
+    }
+}

--- a/fp-core/src/extend.rs
+++ b/fp-core/src/extend.rs
@@ -15,3 +15,12 @@ impl<A, B> Extend<B> for Option<A> {
         self.map(|x| f(Some(x)))
     }
 }
+
+impl<A, B, E> Extend<B> for Result<A, E> {
+    fn extend<W>(self, f: W) -> Self::Target
+    where
+        W: FnOnce(Self) -> B,
+    {
+        self.map(|x| f(Ok(x)))
+    }
+}

--- a/fp-core/src/extract.rs
+++ b/fp-core/src/extract.rs
@@ -7,3 +7,9 @@ impl<A> Extract<A> for Option<A> {
         self.unwrap() // is there a better way to achieve this?
     }
 }
+
+impl<A, E> Extract<A> for Result<A, E> where E: std::fmt::Debug {
+    fn extract(self) -> A {
+        self.unwrap() // is there a better way to achieve this?
+    }
+}

--- a/fp-core/src/functor.rs
+++ b/fp-core/src/functor.rs
@@ -15,3 +15,13 @@ impl<A, B> Functor<B> for Option<A> {
         self.map(f)
     }
 }
+
+impl<A, B, E> Functor<B> for Result<A, E> {
+    fn fmap<F>(self, f: F) -> Self::Target
+    where
+        // A is Self::Current
+        F: FnOnce(A) -> B,
+    {
+        self.map(f)
+    }
+}

--- a/fp-core/src/hkt.rs
+++ b/fp-core/src/hkt.rs
@@ -20,6 +20,11 @@ macro_rules! derive_hkt {
 derive_hkt!(Option);
 derive_hkt!(Vec);
 
+impl<T, U, E> HKT<U> for Result<T, E> {
+    type Current = T;
+    type Target = Result<U, E>;
+}
+
 pub trait HKT3<U1, U2> {
     type Current1;
     type Current2;

--- a/fp-core/src/monad.rs
+++ b/fp-core/src/monad.rs
@@ -4,3 +4,5 @@ use crate::chain::Chain;
 pub trait Monad<A, B>: Chain<B> + Applicative<A, B> {}
 
 impl<A, B> Monad<A, B> for Option<A> where {}
+
+impl<A, B, E> Monad<A, B> for Result<A, E> where {}

--- a/fp-core/src/pure.rs
+++ b/fp-core/src/pure.rs
@@ -9,3 +9,9 @@ impl<A> Pure<A> for Option<A> {
         Some(a)
     }
 }
+
+impl<A, E> Pure<A> for Result<A, E> {
+    fn of(a: A) -> Self::Target {
+        Ok(a)
+    }
+}

--- a/fp-examples/src/applicative_example.rs
+++ b/fp-examples/src/applicative_example.rs
@@ -6,3 +6,9 @@ fn applicative_example() {
     let x = Option::of(1).ap(Some(Box::new(|x| x + 1)));
     assert_eq!(x, Some(2));
 }
+
+#[test]
+fn applicative_example_on_result() {
+    let x = Result::<_,()>::of(1).ap(Ok(Box::new(|x| x + 1)));
+    assert_eq!(x, Ok(2));
+}

--- a/fp-examples/src/functor_example.rs
+++ b/fp-examples/src/functor_example.rs
@@ -32,6 +32,12 @@ fn test_functor() {
     // assert_eq!(vec![5, 6], v.iter().fmap(|x| x + 1).fmap(|x| x + 1));
 }
 
+#[test]
+fn test_functor_for_result() {
+    let z = Result::<_,()>::fmap(Ok(1), |x| x + 1).fmap(|x| x + 1);
+    assert_eq!(z, Ok(3));
+}
+
 /*
 // Below is an old implementation
 #[derive(Debug, PartialEq, Eq)]

--- a/fp-examples/src/monad_example.rs
+++ b/fp-examples/src/monad_example.rs
@@ -6,3 +6,9 @@ fn monad_example() {
     let x = Option::of(1).chain(|x| Some(x + 1));
     assert_eq!(x, Some(2));
 }
+
+#[test]
+fn monad_example_on_result() {
+    let x = Result::<_,()>::of(1).chain(|x| Ok(x + 1));
+    assert_eq!(x, Ok(2));
+}


### PR DESCRIPTION
On similar "functional programming adaptation projects" I have seen `Option` types where the `None` branch actually carries a value and is used to describe errors.

An example is [fp-ts](https://github.com/gcanti/fp-ts) for Typescript.

This is exactly what the Rust `Result` type does, so I added support for it handling it just like `Option`.

This can be useful to chain computations on the "happy path", like when chaining `and_then` calls.
